### PR TITLE
fix: disable pointer events on mountain illustration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,7 @@ APP_KEY=dYmMU1KGTXhI0cmAHHAZi-scEf17PNG-
 DRIVE_DISK=local # production uses gcs
 SESSION_DRIVER=cookie
 CACHE_VIEWS=false
+LOG_LEVEL=info
 
 # add your Postgres details, note I use a separate db for tests
 DB_CONNECTION=postgres
@@ -51,6 +52,9 @@ TURNSTILE_SECRET_KEY=<secret_key>
 # used on schedule page (you can ignore unless you need that page working)
 NOTION_SECRET=<secret>
 NOTION_VERSION=2022-06-28
+NOTION_DB_SERIES=
+NOTION_DB_MODULES=
+NOTION_DB_POSTS=
 
 # stripe 
 STRIPE_ENABLED=false
@@ -61,3 +65,4 @@ STRIPE_WEBHOOK_SECRET=<webhook_secret>
 # not needed locally
 DISCORD_WEBHOOK=<discord_webhook>
 PLAUSIBLE_API_KEY=<api_key>
+IDENTITY_SECRET=

--- a/.env.example
+++ b/.env.example
@@ -13,12 +13,12 @@ SESSION_DRIVER=cookie
 CACHE_VIEWS=false
 
 # add your Postgres details, note I use a separate db for tests
-DB_CONNECTION=pg
-PG_HOST=localhost
-PG_PORT=5432
-PG_USER=lucid
-PG_PASSWORD=
-PG_DB_NAME=lucid
+DB_CONNECTION=postgres
+DB_HOST=localhost
+DB_PORT=5432
+DB_USER=lucid
+DB_PASSWORD=
+DB_DATABASE=lucid
 
 # I use mailtrap.io locally https://mailtrap.io/
 SMTP_HOST=
@@ -61,8 +61,3 @@ STRIPE_WEBHOOK_SECRET=<webhook_secret>
 # not needed locally
 DISCORD_WEBHOOK=<discord_webhook>
 PLAUSIBLE_API_KEY=<api_key>
-DB_HOST=127.0.0.1
-DB_PORT=5432
-DB_USER=postgres
-DB_PASSWORD=
-DB_DATABASE=

--- a/resources/views/components/starfield/index.edge
+++ b/resources/views/components/starfield/index.edge
@@ -10,7 +10,7 @@
   {{{ await $slots.main() }}}
   
   @if (mountain)
-    <div class="absolute z-20 bottom-0 left-0 w-full">
+    <div class="absolute z-20 bottom-0 left-0 w-full pointer-events-none">
       @!illustration.mountain({ class: 'text-body -mb-3' })
     </div>
   @endif

--- a/start/env.ts
+++ b/start/env.ts
@@ -26,8 +26,6 @@ export default await Env.create(new URL('../', import.meta.url), {
   ASSET_DOMAIN: Env.schema.string.optional({ format: 'url' }),
   LOG_LEVEL: Env.schema.string(),
   IDENTITY_SECRET: Env.schema.string(),
-  IPLOCATION_V4: Env.schema.string({ format: 'url' }),
-  IPLOCATION_V6: Env.schema.string({ format: 'url' }),
 
   /*
   |----------------------------------------------------------


### PR DESCRIPTION
hey Tom!

i have a 1440p screen ( so 2560px width ), and on the homepage, the illustration of the mountain goes a bit over the buttons. they are visible, but i can't click on them. you can reproduce this with chrome's device toolbar :

![image](https://github.com/adocasts/adocasts/assets/8337858/ea6608e4-1745-4db6-8cea-6b153d2a2e66)

so i have just disabled the pointer events on the illustration. we can now click on them

---

on top of that ( sorry was too lazy to create another PR ) i've cleaned up a bit the .env.example, which might make it easier for other folks to launch adocasts locally 

- PG_xx are not used. replaced it by DB_xx
- DB_CONNECTION should be `postgres` as this is the connection name defined in `config/database.ts`.
- added some missing example env var's ( LOG_LEVEL, IDENTITY_SECRET )
- and i've also removed `IPLOCATION_V4` and `IPLOCATION_V6` which don't seem to be used anymore